### PR TITLE
Change country translation namespace 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2019-01-29
+
 ### Changed
 
 - Country translation namespace from `countries` to `country` to match Address Form

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Country translation namespace from `countries` to `country` to match Address Form
+
 ## [1.1.0] - 2019-01-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/intl-container",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "A React component for loading i18n translations and intl locale data",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -179,7 +179,7 @@ function createIntlContainer(params) {
       return reduce(
         obj,
         (acc, value, key) => {
-          acc[`countries.${getISOAlpha3(key)}`] = value
+          acc[`country.${getISOAlpha3(key)}`] = value
           return acc
         },
         {}


### PR DESCRIPTION
Change country translation namespace from `countries` to `country` to match Address Form.